### PR TITLE
Exposed functions for getting user info with an access token

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var Crypto = require('crypto');
 function AccountKit() {
   var app_id = "";
   var app_secret = "";
-  var api_version = "v1.1";
+  var api_version = "v1.2";
   var require_app_secret = true;
   var base_url = "https://graph.accountkit.com/";
 
@@ -35,13 +35,11 @@ function AccountKit() {
     getTokenExchangeEnpoint: function() {
       return base_url + api_version + "/access_token";
     },
-    getAccountInfo: function(authorization_code, callback) {
-      var self = this;
-
+    getAccessToken: function(authorization_code, callback) {
       var params = {
         grant_type: 'authorization_code',
         code: authorization_code,
-        access_token: this.getAppAccessToken(),
+        access_token: this.getAppAccessToken()
       };
 
       var token_exchange_url = this.getTokenExchangeEnpoint() + '?' + Querystring.stringify(params);
@@ -56,32 +54,42 @@ function AccountKit() {
         } else if (resp.statusCode !== 200) {
           var errorMsg = "Invalid AccountKit Graph API status code (" + resp.statusCode + ")";
           return callback(errorMsg);
+        } else if (!('access_token' in respBody)) {
+          var errorMsg2 = "Invalid AccountKit Graph API response";
+          return callback(errorMsg2);
         }
-
-        var me_endpoint_url = self.getInfoEndpoint() + '?access_token=' + respBody.access_token;
-        if (require_app_secret) {
-          me_endpoint_url += '&appsecret_proof=' + Crypto.createHmac('sha256', app_secret).update(respBody.access_token).digest('hex');
-        }
-
-        Request.get({
-          url: me_endpoint_url,
-          json: true
-        }, function(error, resp, respBody) {
-          if (error) {
-            return callback(error);
-          } else if (respBody.error) {
-            return callback(respBody.error);
-          } else if (resp.statusCode !== 200) {
-            var errorMsg = "Invalid AccountKit Graph API status code (" + resp.statusCode + ")";
-            return callback(errorMsg);
-          }
-
-          return callback(null, respBody);
-        });
+        return callback(null, respBody.access_token);
       });
     },
+    getAccountInfoWithAccessToken: function(access_token, callback) {
+      var me_endpoint_url = this.getInfoEndpoint() + '?access_token=' + access_token;
+      if (require_app_secret) {
+        me_endpoint_url += '&appsecret_proof=' + Crypto.createHmac('sha256', app_secret).update(access_token).digest('hex');
+      }
+
+      Request.get({
+        url: me_endpoint_url,
+        json: true
+      }, function(error, resp, respBody) {
+        if (error) {
+          return callback(error);
+        } else if (respBody.error) {
+          return callback(respBody.error);
+        } else if (resp.statusCode !== 200) {
+          var errorMsg = "Invalid AccountKit Graph API status code (" + resp.statusCode + ")";
+          return callback(errorMsg);
+        }
+
+        return callback(null, respBody);
+      });
+    },
+    getAccountInfo: function(authorization_code, callback) {
+        var self=this;
+        this.getAccessToken(authorization_code, function(err, access_token) {
+          self.getAccountInfoWithAccessToken(access_token, callback);
+        });
+    },
     removeUser: function(id, callback) {
-      var self = this;
       var delUrl = this.getRemovalEndpoint(id) + "?" + "access_token=" + this.getAppAccessToken();
 
       Request.del({


### PR DESCRIPTION
The current library assumes the client will provide an authorization code and hides the internal methods for exchanging a code for an access token and getting the user info with an access token. I have updated the library to support both flows (code or access token). I have left the convenience method getAccountInfo for backwards compatibility. But now the library exposes all use cases for the Access Kit Graph API. 